### PR TITLE
Create the output directory when it doesn't exist

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -89,9 +89,9 @@ echo "Packaging zip archive"
 
 zip "${PACKAGING_INSTALLER_NAME}-${TAG}" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet --symlinks
 
-mv "${PACKAGING_INSTALLER_NAME}-${TAG}.zip" ${OUTPUTDIR}
-
 popd > /dev/null
+
+mv "${BUILTDIR}/${PACKAGING_INSTALLER_NAME}-${TAG}.zip" "${OUTPUTDIR}"
 
 # Clean up
 rm -rf "${BUILTDIR}"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -58,6 +58,11 @@ if [ ! -f "${ENGINE_DIRECTORY}/Makefile" ]; then
 	exit 1
 fi
 
+if [ ! -d "${OUTPUTDIR}" ]; then
+	echo "Output directory '${OUTPUTDIR}' does not exist.";
+	exit 1
+fi
+
 make version VERSION="${TAG}"
 
 pushd ${ENGINE_DIRECTORY} > /dev/null
@@ -83,6 +88,7 @@ modify_plist "{JOIN_SERVER_URL_SCHEME}" "openra-${MOD_ID}-${TAG}" "${PACKAGING_O
 echo "Packaging zip archive"
 
 zip "${PACKAGING_INSTALLER_NAME}-${TAG}" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet --symlinks
+
 mv "${PACKAGING_INSTALLER_NAME}-${TAG}.zip" ${OUTPUTDIR}
 
 popd > /dev/null

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne "2" ]; then
-    echo "Usage: `basename $0` version outputdir"
+if [ $# -ne "1" ]; then
+    echo "Usage: `basename $0` version"
     exit 1
 fi
+
+command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+OUTPUTDIR=$(python -c "import os; print(os.path.realpath('.'))")
 
 # Set the working dir to the location of this script
 cd "$(dirname $0)"
 
 pushd windows >/dev/null
 echo "Building Windows package"
-./buildpackage.sh "$1" "$2"
+./buildpackage.sh "$1" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "Windows package build failed."
 fi
@@ -19,7 +22,7 @@ popd >/dev/null
 
 pushd osx >/dev/null
 echo "Building macOS package"
-./buildpackage.sh "$1" "$2"
+./buildpackage.sh "$1" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "macOS package build failed."
 fi

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -7,6 +7,10 @@ if [ $# -ne "1" ]; then
 fi
 
 command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v makensis >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires makensis."; exit 1; }
+
 OUTPUTDIR=$(python -c "import os; print(os.path.realpath('.'))")
 
 # Set the working dir to the location of this script

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -45,6 +45,11 @@ if [ ! -f "${ENGINE_DIRECTORY}/Makefile" ]; then
 	exit 1
 fi
 
+if [ ! -d "${OUTPUTDIR}" ]; then
+	echo "Output directory '${OUTPUTDIR}' does not exist.";
+	exit 1
+fi
+
 make version VERSION="${TAG}"
 
 pushd ${ENGINE_DIRECTORY} > /dev/null


### PR DESCRIPTION
Fixes #34.

Packaging should now also work with relative paths.
Edit: And the output directory defaults to the current directory.