### PR TITLE
Rename .zip package for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
   api_key: ${GH_DEPLOY_API_KEY}
   file:
     - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}.exe
-    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}.zip
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-macOS.zip
   skip_cleanup: true
   on:
     tags: true

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -92,8 +92,8 @@ modify_plist "{JOIN_SERVER_URL_SCHEME}" "openra-${MOD_ID}-${TAG}" "${PACKAGING_O
 
 echo "Packaging zip archive"
 
-zip "${PACKAGING_INSTALLER_NAME}-${TAG}.zip" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet --symlinks
-mv "${PACKAGING_INSTALLER_NAME}-${TAG}.zip" "${OUTPUTDIR}"
+zip "${PACKAGING_INSTALLER_NAME}-${TAG}-macOS.zip" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet --symlinks
+mv "${PACKAGING_INSTALLER_NAME}-${TAG}-macOS.zip" "${OUTPUTDIR}"
 popd > /dev/null
 
 # Clean up


### PR DESCRIPTION
This is to avoid confusion with the .zip package from https://github.com/OpenRA/OpenRAModSDK/pull/61.