### PR TITLE
Replace INCLUDE_DEFAULT_MODS with PACKAGING_COPY_ENGINE_FILES

### DIFF
--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -10,6 +10,7 @@ command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires 
 
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods,./mods"
 
 # shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
@@ -17,11 +18,6 @@ TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
 if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	# shellcheck source=user.config
 	. "${TEMPLATE_ROOT}/user.config"
-fi
-
-MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS},./mods"
 fi
 
 NAME="${Name:-"Dedicated Server"}"

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -6,6 +6,7 @@ command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires 
 
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods,./mods"
 
 # shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
@@ -13,11 +14,6 @@ TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
 if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	# shellcheck source=user.config
 	. "${TEMPLATE_ROOT}/user.config"
-fi
-
-MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS},./mods"
 fi
 
 cd "${TEMPLATE_ROOT}"

--- a/make.ps1
+++ b/make.ps1
@@ -217,7 +217,7 @@ function ReadConfigLine($line, $name)
 
 function ParseConfigFile($fileName)
 {
-	$names = @("MOD_ID", "INCLUDE_DEFAULT_MODS", "ENGINE_VERSION", "AUTOMATIC_ENGINE_MANAGEMENT", "AUTOMATIC_ENGINE_SOURCE",
+	$names = @("MOD_ID", "ENGINE_VERSION", "AUTOMATIC_ENGINE_MANAGEMENT", "AUTOMATIC_ENGINE_SOURCE",
 		"AUTOMATIC_ENGINE_EXTRACT_DIRECTORY", "AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME", "ENGINE_DIRECTORY")
 
 	$reader = [System.IO.File]::OpenText($fileName)
@@ -272,11 +272,7 @@ if (Test-Path "user.config")
 
 $modID = $env:MOD_ID
 
-$env:MOD_SEARCH_PATHS = (Get-Item -Path ".\" -Verbose).FullName + "\mods"
-if ($env:INCLUDE_DEFAULT_MODS -eq "True")
-{
-	$env:MOD_SEARCH_PATHS = $env:MOD_SEARCH_PATHS + ",./mods"
-}
+$env:MOD_SEARCH_PATHS = (Get-Item -Path ".\" -Verbose).FullName + "\mods,./mods"
 
 # Run the same command on the engine's make file
 if ($command -eq "all" -or $command -eq "clean")

--- a/mod.config
+++ b/mod.config
@@ -11,12 +11,6 @@ MOD_ID="example"
 # The OpenRA engine version to use for this project.
 ENGINE_VERSION="release-20180307"
 
-# Enable this to make the default OpenRA mods available for use in your mod.yaml
-# Packages list (via $mod references). Accepts values "True" or "False".
-# WARNING: This setting is provided to simplify early project development,
-# and must be disabled before you can package installers for your project!
-INCLUDE_DEFAULT_MODS="False"
-
 ##############################################################################
 # Continuous Integration
 #

--- a/mod.config
+++ b/mod.config
@@ -86,6 +86,10 @@ PACKAGING_WINDOWS_REGISTRY_KEY="OpenRAExampleMod"
 # The git tag to use for the AppImage dependencies.
 PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20180408"
 
+# Space delimited list of additional files/directories to copy from the engine directory
+# when packaging your mod. e.g. "./mods/modcontent" or "./mods/d2k/OpenRA.Mods.D2k.dll"
+PACKAGING_COPY_ENGINE_FILES=""
+
 ##############################################################################
 # Advanced Configuration
 #

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -23,12 +23,6 @@ if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	. "${TEMPLATE_ROOT}/user.config"
 fi
 
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	echo "Cannot generate installers while INCLUDE_DEFAULT_MODS is enabled."
-	echo "Make sure that this setting is disabled in both your mod.config and user.config."
-	exit 1
-fi
-
 TAG="$1"
 if [ $# -eq "1" ]; then
 	OUTPUTDIR=$(python -c "import os; print(os.path.realpath('.'))")

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -64,6 +64,11 @@ make core SDK="-sdk:4.5"
 make install-engine prefix="usr" DESTDIR="${BUILTDIR}/"
 make install-common-mod-files prefix="usr" DESTDIR="${BUILTDIR}/"
 
+for f in ${PACKAGING_COPY_ENGINE_FILES}; do
+  mkdir -p "${BUILTDIR}/usr/lib/openra/$(dirname "${f}")"
+  cp -r "${f}" "${BUILTDIR}/usr/lib/openra/${f}"
+done
+
 popd > /dev/null
 popd > /dev/null
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -75,6 +75,12 @@ make osx-dependencies
 make core SDK="-sdk:4.5"
 make install-engine gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
 make install-common-mod-files gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
+
+for f in ${PACKAGING_COPY_ENGINE_FILES}; do
+  mkdir -p "${BUILTDIR}/OpenRA.app/Contents/Resources/$(dirname "${f}")"
+  cp -r "${f}" "${BUILTDIR}/OpenRA.app/Contents/Resources/${f}"
+done
+
 popd > /dev/null
 popd > /dev/null
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -22,12 +22,6 @@ if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	. "${TEMPLATE_ROOT}/user.config"
 fi
 
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	echo "Cannot generate installers while INCLUDE_DEFAULT_MODS is enabled."
-	echo "Make sure that this setting is disabled in both your mod.config and user.config."
-	exit 1
-fi
-
 TAG="$1"
 if [ $# -eq "1" ]; then
 	OUTPUTDIR=$(python -c "import os; print(os.path.realpath('.'))")

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -63,6 +63,12 @@ make windows-dependencies
 make core SDK="-sdk:4.5"
 make install-engine gameinstalldir="" DESTDIR="${BUILTDIR}"
 make install-common-mod-files gameinstalldir="" DESTDIR="${BUILTDIR}"
+
+for f in ${PACKAGING_COPY_ENGINE_FILES}; do
+  mkdir -p "${BUILTDIR}/$(dirname "${f}")"
+  cp -r "${f}" "${BUILTDIR}/${f}"
+done
+
 popd > /dev/null
 popd > /dev/null
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -20,12 +20,6 @@ if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	. "${TEMPLATE_ROOT}/user.config"
 fi
 
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	echo "Cannot generate installers while INCLUDE_DEFAULT_MODS is enabled."
-	echo "Make sure that this setting is disabled in both your mod.config and user.config."
-	exit 1
-fi
-
 TAG="$1"
 if [ $# -eq "1" ]; then
 	OUTPUTDIR=$(python -c "import os; print(os.path.realpath('.'))")

--- a/utility.sh
+++ b/utility.sh
@@ -10,6 +10,7 @@ command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires 
 
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods,./mods"
 
 # shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
@@ -17,11 +18,6 @@ TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
 if [ -f "${TEMPLATE_ROOT}/user.config" ]; then
 	# shellcheck source=user.config
 	. "${TEMPLATE_ROOT}/user.config"
-fi
-
-MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
-if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
-	MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS},./mods"
 fi
 
 LAUNCH_MOD="${Mod:-"${MOD_ID}"}"


### PR DESCRIPTION
This PR is designed to solve two use cases:
* Simplifying life for overlay-style mods that, like map mods, want to inherit wholesale from one of the default mods and then apply override rule files.
* Allowing mods to copy specific files (e.g. dlls or maps) from a default mod without copying the entire tree into their SDK dir.

Closes #74.

See [pchote/ra-example-mod](https://github.com/pchote/OpenRAModSDK/tree/ra-example-mod) for an example which packages [Smitty's Sprint 2018 Playtest](http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=20512) as a mod.

After this is merged we will need to update [Generating Release Installers](https://github.com/OpenRA/OpenRAModSDK/wiki/Generating-Release-Installers) to replace the comment about `INCLUDE_DEFAULT_MODS` with a comment about how any files used from the engine/mods dir *must* be listed in `PACKAGING_COPY_ENGINE_FILES` and it would be nice if [Getting Started](https://github.com/OpenRA/OpenRAModSDK/wiki/Getting-Started) could be expanded with an example of an overlay mod. 