### PR TITLE
Resolve symlinks to their underlying paths when packaging.

### DIFF
--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -78,7 +78,7 @@ chmod a+x appimagetool-x86_64.AppImage
 echo "Building AppImage"
 
 # Add mod files
-cp -r "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/usr/lib/openra/mods"
+cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/usr/lib/openra/mods"
 
 install -Dm 0755 libSDL2.so "${BUILTDIR}/usr/lib/openra/"
 install -Dm 0644 include/SDL2-CS.dll.config "${BUILTDIR}/usr/lib/openra/"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -79,7 +79,7 @@ popd > /dev/null
 popd > /dev/null
 
 # Add mod files
-cp -r "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
+cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
 cp "mod.icns" "${BUILTDIR}/OpenRA.app/Contents/Resources/${MOD_ID}.icns"
 
 pushd "${BUILTDIR}" > /dev/null
@@ -92,7 +92,7 @@ modify_plist "{JOIN_SERVER_URL_SCHEME}" "openra-${MOD_ID}-${TAG}" "${PACKAGING_O
 
 echo "Packaging zip archive"
 
-zip "${PACKAGING_INSTALLER_NAME}-${TAG}-macOS.zip" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet --symlinks
+zip "${PACKAGING_INSTALLER_NAME}-${TAG}-macOS.zip" -r -9 "${PACKAGING_OSX_APP_NAME}" --quiet
 mv "${PACKAGING_INSTALLER_NAME}-${TAG}-macOS.zip" "${OUTPUTDIR}"
 popd > /dev/null
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -67,7 +67,7 @@ popd > /dev/null
 popd > /dev/null
 
 # Add mod files
-cp -r "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/mods"
+cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/mods"
 cp "mod.ico" "${BUILTDIR}/${MOD_ID}.ico"
 cp "${SRC_DIR}/OpenRA.Game.exe.config" "${BUILTDIR}"
 
@@ -88,7 +88,7 @@ popd > /dev/null
 echo "Packaging zip archive"
 pushd "${BUILTDIR}" > /dev/null
 find "${SRC_DIR}/thirdparty/download/windows/" -name '*.dll' -exec cp '{}' '.' ';'
-zip "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable" -r -9 * --quiet --symlinks
+zip "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable" -r -9 * --quiet
 mv "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable.zip" "${OUTPUTDIR}"
 popd > /dev/null
 


### PR DESCRIPTION
Fixes #65.