### PR TITLE
Port upstream AppImage improvements.

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -56,7 +56,7 @@ PACKAGING_DISPLAY_NAME="Example Mod"
 #  - Windows "Add/Remove Programs" list
 PACKAGING_WEBSITE_URL="http://openra.net"
 
-# The URL that is opened when a player presses the "FAQ" button in the crash dialog.
+# The URL that is displayed in the crash dialog.
 PACKAGING_FAQ_URL="http://wiki.openra.net/FAQ"
 
 # The human-readable project authors.

--- a/packaging/linux/include/AppRun.in
+++ b/packaging/linux/include/AppRun.in
@@ -15,11 +15,13 @@ mono_missing_or_old() {
 }
 
 if mono_missing_or_old; then
-  if command -v zenity > /dev/null
-  then
-    zenity --no-wrap --error --title "{MODNAME}" --text "{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager."
+  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager."
+  if command -v zenity > /dev/null; then
+    zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
+  elif command -v kdialog > /dev/null; then
+    kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
   else
-    printf "{MODNAME} requires Mono %s or greater.\nPlease install Mono using your system package manager.\n" "${MINIMUM_MONO_VERSION}"
+    printf "${ERROR_MESSAGE}"
   fi
   exit 1
 fi

--- a/packaging/linux/include/mod.desktop.in
+++ b/packaging/linux/include/mod.desktop.in
@@ -7,5 +7,5 @@ Icon=openra-{MODID}
 Exec=openra-{MODID} %u
 Terminal=false
 Categories=Game;StrategyGame;
-StartupWMClass=openra-{MODID}
+StartupWMClass=openra-{MODID}-{TAG}
 MimeType=x-scheme-handler/openra-{MODID}-{TAG};

--- a/packaging/linux/include/mod.in
+++ b/packaging/linux/include/mod.in
@@ -9,9 +9,9 @@ cd "${HERE}/../lib/openra" || exit 1
 if [ ! -z "${APPIMAGE}" ]; then
   LAUNCHER=${APPIMAGE}
 
-  # appimaged doesn't update the mime cache database when registering AppImages.
-  # Run update-desktop-database ourselves if we detect that the desktop file has
-  # been installed but the handler is not yet present in the cache
+  # appimaged doesn't update the mime or icon caches when registering AppImages.
+  # Run update-desktop-database and gtk-update-icon-cache ourselves if we detect
+  # that the desktop file has been installed but the handler is not cached
   if command -v update-desktop-database > /dev/null; then
     APPIMAGEID=$(printf "file://%s" "${APPIMAGE}" | md5sum | cut -d' ' -f1)
     LAUNCHER_NAME="appimagekit_${APPIMAGEID}-openra-{MODID}.desktop"
@@ -20,6 +20,9 @@ if [ ! -z "${APPIMAGE}" ]; then
     SCHEME="x-scheme-handler/openra-{MODID}-{TAG}"
     if [ -f "${LAUNCHER_PATH}" ] && ! grep -qs "${SCHEME}=" "${MIMECACHE_PATH}"; then
         update-desktop-database "${HOME}/.local/share/applications"
+        if command -v gtk-update-icon-cache > /dev/null; then
+          gtk-update-icon-cache ~/.local/share/icons/hicolor/ -t
+        fi
     fi
   fi
 fi
@@ -32,15 +35,18 @@ if [ "${1#${PROTOCOL_PREFIX}}" != "${1}" ]; then
 fi
 
 # Run the game
-export SDL_VIDEO_X11_WMCLASS="openra-{MODID}"
+export SDL_VIDEO_X11_WMCLASS="openra-{MODID}-{TAG}"
 mono --debug OpenRA.Game.exe Game.Mod={MODID} Engine.LaunchPath="${LAUNCHER}" "${JOIN_SERVER}" "$@"
 
 # Show a crash dialog if something went wrong
 if [ $? != 0 ] && [ $? != 1 ]; then
+  ERROR_MESSAGE="{MODNAME} has encountered a fatal error.\nPlease refer to the crash logs and FAQ for more information.\n\nLog files are located in ~/.openra/Logs\nThe FAQ is available at {MODFAQURL}"
   if command -v zenity > /dev/null; then
-    zenity --no-wrap --question --title "{MODNAME}" --text "{MODNAME} has encountered a fatal error.\nLog Files are available in ~/.openra." --ok-label "Quit" --cancel-label "View FAQ" || xdg-open "{MODFAQURL}"
+    zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
+  elif command -v kdialog > /dev/null; then
+    kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
   else
-    printf "{MODNAME} has encountered a fatal error.\n  -> Log Files are available in ~/.openra\n  -> FAQ is available at {MODFAQURL}\n"
+    printf "${ERROR_MESSAGE}\n"
   fi
   exit 1
 fi


### PR DESCRIPTION
This PR backports the improvements from https://github.com/OpenRA/OpenRA/pull/15086:
- Improved crash dialogs (including KDE support)
- Distinguish WMStartupClass using versions
- Refresh the icon cache on first run

They have already been reviewed upstream, so merging immediately.