### PR TITLE
Update AppImage libraries to 20180723 tag.

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -81,7 +81,7 @@ PACKAGING_WINDOWS_REGISTRY_KEY="OpenRAExampleMod"
 PACKAGING_WINDOWS_LICENSE_FILE="./COPYING"
 
 # The git tag to use for the AppImage dependencies.
-PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20180408"
+PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20180723"
 
 # Space delimited list of additional files/directories to copy from the engine directory
 # when packaging your mod. e.g. "./mods/modcontent" or "./mods/d2k/OpenRA.Mods.D2k.dll"


### PR DESCRIPTION
Counterpart to https://github.com/OpenRA/OpenRA/pull/15374.