### PR TITLE
Update macOS launcher template to osx-launcher-20180723.

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -65,7 +65,7 @@ PACKAGING_FAQ_URL="http://wiki.openra.net/FAQ"
 PACKAGING_AUTHORS="Example Mod authors"
 
 # The git tag to use for the macOS Launcher files.
-PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20171118"
+PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20180723"
 
 # Filename to use for the launcher executable on Windows.
 PACKAGING_WINDOWS_LAUNCHER_NAME="ExampleMod"


### PR DESCRIPTION
Counterpart to https://github.com/OpenRA/OpenRA/pull/15379.