### PR TITLE
Adding wget support to Linux fetch and build scripts.

### DIFF
--- a/fetch-engine.sh
+++ b/fetch-engine.sh
@@ -2,7 +2,7 @@
 # Helper script used to check and update engine dependencies
 # This should not be called manually
 
-command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl or wget."; exit 1; }
 command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
 
 require_variables() {
@@ -52,7 +52,11 @@ if [ "${AUTOMATIC_ENGINE_MANAGEMENT}" = "True" ]; then
 	fi
 
 	echo "Downloading engine..."
-	curl -s -L -o "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}" -O "${AUTOMATIC_ENGINE_SOURCE}" || exit 3
+	if command -v curl > /dev/null 2>&1; then
+		curl -s -L -o "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}" -O "${AUTOMATIC_ENGINE_SOURCE}" || exit 3
+	else
+		wget -cq "${AUTOMATIC_ENGINE_SOURCE}" -O "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}" || exit 3
+	fi
 
 	# Github zipballs package code with a top level directory named based on the refspec
 	# Extract to a temporary directory and then move the subdir to our target location

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -5,7 +5,7 @@ set -e
 command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
 command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
 command -v tar >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires tar."; exit 1; }
-command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl or wget."; exit 1; }
 
 require_variables() {
 	missing=""
@@ -90,10 +90,14 @@ popd > /dev/null
 
 # Add native libraries
 echo "Downloading dependencies"
-curl -s -L -o "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" -O "${PACKAGING_APPIMAGE_DEPENDENCIES_SOURCE}" || exit 3
+if command -v curl >/dev/null 2>&1; then
+	curl -s -L -o "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" -O "${PACKAGING_APPIMAGE_DEPENDENCIES_SOURCE}" || exit 3
+	curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+else
+	wget -cq "${PACKAGING_APPIMAGE_DEPENDENCIES_SOURCE}" -O "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" || exit 3
+	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+fi
 tar xf "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}"
-
-curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 chmod a+x appimagetool-x86_64.AppImage
 
 echo "Building AppImage"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -4,7 +4,7 @@ set -e
 
 command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
 command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
-command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl or wget."; exit 1; }
 
 require_variables() {
 	missing=""
@@ -56,7 +56,12 @@ modify_plist() {
 }
 
 echo "Building launcher"
-curl -s -L  -o "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}" -O "${PACKAGING_OSX_LAUNCHER_SOURCE}" || exit 3
+
+if command -v curl >/dev/null 2>&1; then
+	curl -s -L -o "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}" -O "${PACKAGING_OSX_LAUNCHER_SOURCE}" || exit 3
+else
+	wget -cq "${PACKAGING_OSX_LAUNCHER_SOURCE}" -O "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}" || exit 3
+fi
 
 unzip -qq -d "${BUILTDIR}" "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}"
 rm "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}"

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -15,7 +15,7 @@ fi
 
 command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
 command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
-command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl or wget."; exit 1; }
 command -v makensis >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires makensis."; exit 1; }
 
 PACKAGING_DIR=$(python -c "import os; print(os.path.dirname(os.path.realpath('$0')))")

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e
-
-command -v curl >/dev/null 2>&1 || { echo >&2 "Windows packaging requires curl."; exit 1; }
 command -v makensis >/dev/null 2>&1 || { echo >&2 "Windows packaging requires makensis."; exit 1; }
 
 require_variables() {


### PR DESCRIPTION
Hi,

This pull request is really just a follow up of OpenRA/OpenRA#15351, wherein I add wget support to the Linux-centric scripts for fetching and building. I did wonder whether I should also add support to the [package-all.sh](https://github.com/OpenRA/OpenRAModSDK/blob/master/packaging/package-all.sh), [osx buildpackage.sh](https://github.com/OpenRA/OpenRAModSDK/blob/master/packaging/osx/buildpackage.sh) and [windows buildpackage.sh](https://github.com/OpenRA/OpenRAModSDK/blob/master/packaging/windows/buildpackage.sh) scripts for wget, but they're mostly just used by the project's Travis CI instance so I do not think that's really necessary. Although if you's believe I should I will be happy to. If I do, however, I should probably also do so for the main project, https://github.com/OpenRA/OpenRA. 

Thanks for your time,
Brenton