### PR TITLE
Remove all uses of ExternalPort

### DIFF
--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -4,7 +4,6 @@
 
 set Name="Dedicated Server"
 set ListenPort=1234
-set ExternalPort=1234
 set AdvertiseOnline=True
 set EnableSingleplayer=False
 set Password=""
@@ -26,7 +25,7 @@ if not exist %ENGINE_DIRECTORY%\OpenRA.Game.exe goto noengine
 cd %ENGINE_DIRECTORY%
 
 :loop
-OpenRA.Server.exe Game.Mod=%MOD_ID% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
+OpenRA.Server.exe Game.Mod=%MOD_ID% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
 goto loop
 
 :noengine

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -37,7 +37,6 @@ require_variables "MOD_ID" "ENGINE_VERSION" "ENGINE_DIRECTORY"
 NAME="${Name:-"Dedicated Server"}"
 LAUNCH_MOD="${Mod:-"${MOD_ID}"}"
 LISTEN_PORT="${ListenPort:-"1234"}"
-EXTERNAL_PORT="${ExternalPort:-"1234"}"
 ADVERTISE_ONLINE="${AdvertiseOnline:-"True"}"
 ENABLE_SINGLE_PLAYER="${EnableSingleplayer:-"False"}"
 PASSWORD="${Password:-""}"
@@ -53,7 +52,7 @@ cd "${ENGINE_DIRECTORY}"
 
 while true; do
      MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS}" mono --debug OpenRA.Server.exe Game.Mod="${LAUNCH_MOD}" \
-     Server.Name="${NAME}" Server.ListenPort="${LISTEN_PORT}" Server.ExternalPort="${EXTERNAL_PORT}" \
+     Server.Name="${NAME}" Server.ListenPort="${LISTEN_PORT}" \
      Server.AdvertiseOnline="${ADVERTISE_ONLINE}" \
      Server.EnableSingleplayer="${ENABLE_SINGLE_PLAYER}" Server.Password="${PASSWORD}"
 done

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -70,7 +70,7 @@ MOD_VERSION=$(grep 'Version:' mods/${MOD_ID}/mod.yaml | awk '{print $2}')
 
 if [ "${PACKAGING_OVERWRITE_MOD_VERSION}" == "True" ]; then
     make version VERSION="${TAG}"
-else	
+else
 	echo "Mod version ${MOD_VERSION} will remain unchanged.";
 fi
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -82,7 +82,7 @@ MOD_VERSION=$(grep 'Version:' mods/${MOD_ID}/mod.yaml | awk '{print $2}')
 
 if [ "${PACKAGING_OVERWRITE_MOD_VERSION}" == "True" ]; then
     make version VERSION="${TAG}"
-else	
+else
 	echo "Mod version ${MOD_VERSION} will remain unchanged.";
 fi
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -69,7 +69,7 @@ MOD_VERSION=$(grep 'Version:' mods/${MOD_ID}/mod.yaml | awk '{print $2}')
 
 if [ "${PACKAGING_OVERWRITE_MOD_VERSION}" == "True" ]; then
     make version VERSION="${TAG}"
-else	
+else
 	echo "Mod version ${MOD_VERSION} will remain unchanged.";
 fi
 


### PR DESCRIPTION
We already removed `ExternalPort` upstream.
Also removes trailing tabs from the `buildpackage.sh` scripts.