### PR TITLE
Add makefile checks for common errors introduced by windows-only developers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 script:
  - make
  - . mod.config;
+   awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; travis_terminate 1);
    if [ "${TRAVIS_TEST_MOD}" == "True" ]; then make test || travis_terminate 1; fi;
    if [ "${TRAVIS_TEST_PACKAGING}" == "True" ]; then ./packaging/package-all.sh test-0 || travis_terminate 1; fi
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ HAS_LUAC = $(shell command -v luac 2> /dev/null)
 LUA_FILES = $(shell find mods/*/maps/* -iname '*.lua')
 PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_DIRECTORY)/*"))
 
+scripts:
+	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+
 variables:
-	@if [ -z "$(MOD_ID)" ] || [ -z "$(ENGINE_DIRECTORY)" ];then \
+	@if [ -z "$(MOD_ID)" ] || [ -z "$(ENGINE_DIRECTORY)" ]; then \
 			echo "Required mod.config variables are missing:"; \
 			if [ -z "$(MOD_ID)" ]; then \
 				echo "   MOD_ID"; \
@@ -47,7 +50,7 @@ variables:
 			exit 1; \
 		fi
 
-engine: variables
+engine: variables scripts
 	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
 	@cd $(ENGINE_DIRECTORY) && make core
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,26 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
 
 scripts:
 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+		echo "Required SDK scripts are not executable:"; \
+		if [ ! -x "fetch-engine.sh" ]; then \
+			echo "   fetch-engine.sh"; \
+		fi; \
+		if [ ! -x "launch-dedicated.sh" ]; then \
+			echo "   launch-dedicated.sh"; \
+		fi; \
+		if [ ! -x "launch-game.sh" ]; then \
+			echo "   launch-game.sh"; \
+		fi; \
+		if [ ! -x "utility.sh" ]; then \
+			echo "   utility.sh"; \
+		fi; \
+		echo "Repair their permissions and try again."; \
+		echo "If you are using git you can repair these permissions by running"; \
+		echo "   git update-index --chmod=+x *.sh"; \
+		echo "and commiting the changed files to your repository."; \
+		exit 1; \
+	fi
 
 variables:
 	@if [ -z "$(MOD_ID)" ] || [ -z "$(ENGINE_DIRECTORY)" ]; then \


### PR DESCRIPTION
Fixes #97.

Testcase 1: `unix2dos mod.config && make`
Testcase 2: `chmod a-x launch-game.sh && make`