### PR TITLE
Explicitly include the zip extension in the windows packaging.

### DIFF
--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -112,7 +112,7 @@ popd > /dev/null
 echo "Packaging zip archive"
 pushd "${BUILTDIR}" > /dev/null
 find "${SRC_DIR}/thirdparty/download/windows/" -name '*.dll' -exec cp '{}' '.' ';'
-zip "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable" -r -9 * --quiet
+zip "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable.zip" -r -9 * --quiet
 mv "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable.zip" "${OUTPUTDIR}"
 popd > /dev/null
 


### PR DESCRIPTION
Fixes #105.