### PR TITLE
Revert macOS dark mode support.

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -65,7 +65,7 @@ PACKAGING_FAQ_URL="http://wiki.openra.net/FAQ"
 PACKAGING_AUTHORS="Example Mod authors"
 
 # The git tag to use for the macOS Launcher files.
-PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20180723"
+PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20171118"
 
 # Filename to use for the launcher executable on Windows.
 PACKAGING_WINDOWS_LAUNCHER_NAME="ExampleMod"


### PR DESCRIPTION
Counterpart to https://github.com/OpenRA/OpenRA/pull/15635.

Reverts #91.