### PR TITLE
Update scripts to work with the new engine toolchain.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 # Travis-CI Build for OpenRAModSDK
 # see travis-ci.org for details
 
+dist: xenial
 language: csharp
-mono: 4.6.1
-sudo: false
+mono: 5.20.1
 
 addons:
   apt:
     packages:
+    - dpkg
     - liblua5.1-0
-    - nsis
-    - nsis-common
 
 script:
  - make
@@ -20,18 +19,23 @@ script:
    if [ "${TRAVIS_TEST_PACKAGING}" == "True" ]; then make check-packaging-scripts && ./packaging/package-all.sh test-0 || travis_terminate 1; fi
 
 before_deploy:
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb
+ - sudo dpkg -i nsis-common_3.03-2_all.deb
+ - sudo dpkg -i nsis_3.03-2_amd64.deb
  - mkdir build
  - make check-packaging-scripts && cd build && ../packaging/package-all.sh ${TRAVIS_TAG} ${PWD} && cd ..
- - . mod.config
 
 deploy:
   provider: releases
   api_key: ${GH_DEPLOY_API_KEY}
   file:
-    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}.exe
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-x86.exe
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-x64.exe
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-x86-winportable.zip
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-x64-winportable.zip
     - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-macOS.zip
-    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-winportable.zip
-    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}.AppImage
+    - build/${PACKAGING_INSTALLER_NAME}-${TRAVIS_TAG}-x86_64.AppImage
   skip_cleanup: true
   on:
     tags: true

--- a/ExampleMod.sln
+++ b/ExampleMod.sln
@@ -9,21 +9,28 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Mods.Common", "engin
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Release-x86|Any CPU = Release-x86|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Debug|x86.ActiveCfg = Debug|x86
-		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Debug|x86.Build.0 = Debug|x86
-		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release|x86.ActiveCfg = Release|x86
-		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release|x86.Build.0 = Release|x86
-		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Debug|x86.ActiveCfg = Debug|x86
-		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Debug|x86.Build.0 = Debug|x86
-		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release|x86.ActiveCfg = Release|x86
-		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release|x86.Build.0 = Release|x86
-		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Debug|x86.ActiveCfg = Debug|x86
-		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Debug|x86.Build.0 = Debug|x86
-		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release|x86.ActiveCfg = Release|x86
-		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release|x86.Build.0 = Release|x86
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release-x86|Any CPU.ActiveCfg = Release|Any CPU
+		{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}.Release-x86|Any CPU.Build.0 = Release|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release-x86|Any CPU.ActiveCfg = Release-x86|Any CPU
+		{0DFB103F-2962-400F-8C6D-E2C28CCBA633}.Release-x86|Any CPU.Build.0 = Release-x86|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release-x86|Any CPU.ActiveCfg = Release|Any CPU
+		{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}.Release-x86|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,26 @@
 #   make check-packaging-scripts
 
 .PHONY: utility stylecheck build clean engine version check check-scripts check-sdk-scripts check-packaging-scripts check-variables
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := all
 
 VERSION = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 MOD_ID = $(shell cat user.config mod.config 2> /dev/null | awk -F= '/MOD_ID/ { print $$2; exit }')
 ENGINE_DIRECTORY = $(shell cat user.config mod.config 2> /dev/null | awk -F= '/ENGINE_DIRECTORY/ { print $$2; exit }')
 MOD_SEARCH_PATHS = "$(shell python -c "import os; print(os.path.realpath('.'))")/mods,./mods"
 
-MANIFEST_PATH = "mods/$(MOD_ID)/mod.yaml"
+WHITELISTED_OPENRA_ASSEMBLIES = "$(shell cat user.config mod.config 2> /dev/null | awk -F= '/WHITELISTED_OPENRA_ASSEMBLIES/ { print $$2; exit }')"
+WHITELISTED_THIRDPARTY_ASSEMBLIES = "$(shell cat user.config mod.config 2> /dev/null | awk -F= '/WHITELISTED_THIRDPARTY_ASSEMBLIES/ { print $$2; exit }')"
+WHITELISTED_CORE_ASSEMBLIES = "$(shell cat user.config mod.config 2> /dev/null | awk -F= '/WHITELISTED_CORE_ASSEMBLIES/ { print $$2; exit }')"
+WHITELISTED_MOD_ASSEMBLIES = "$(shell cat user.config mod.config 2> /dev/null | awk -F= '/WHITELISTED_MOD_ASSEMBLIES/ { print $$2; exit }')"
 
-HAS_MSBUILD = $(shell command -v msbuild 2> /dev/null)
+MANIFEST_PATH = "mods/$(MOD_ID)/mod.yaml"
 HAS_LUAC = $(shell command -v luac 2> /dev/null)
-LUA_FILES = $(shell find mods/*/maps/* -iname '*.lua')
-PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_DIRECTORY)/*"))
+LUA_FILES = $(shell find mods/*/maps/* -iname '*.lua' 2> /dev/null)
+
+MSBUILD = msbuild -verbosity:m -nologo
+
+# Enable 32 bit builds while generating the windows installer
+WIN32 = false
 
 check-sdk-scripts:
 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
@@ -94,29 +101,32 @@ check-variables:
 		exit 1; \
 	fi
 
+engine-dependencies: check-variables check-sdk-scripts
+	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+	@cd $(ENGINE_DIRECTORY) && make dependencies WIN32=$(WIN32)
+
 engine: check-variables check-sdk-scripts
 	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
-	@cd $(ENGINE_DIRECTORY) && make core
+	@cd $(ENGINE_DIRECTORY) && make core WIN32=$(WIN32)
 
-utility: engine
+utility: engine-dependencies engine
 	@test -f "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" || (printf "OpenRA.Utility.exe not found!\n"; exit 1)
 
-stylecheck: engine
-	@test -f "$(ENGINE_DIRECTORY)/OpenRA.StyleCheck.exe" || (cd $(ENGINE_DIRECTORY) && make stylecheck)
-
-build: engine
-ifeq ("$(HAS_MSBUILD)","")
-	@find . -maxdepth 1 -name '*.sln' -exec xbuild /nologo /verbosity:quiet /p:TreatWarningsAsErrors=true \;
+core:
+	@command -v $(MSBUILD) >/dev/null || (echo "OpenRA requires the '$(MSBUILD)' tool provided by Mono >= 5.4."; exit 1)
+	@find . -maxdepth 1 -name '*.sln' -exec $(MSBUILD) -t:restore \;
+ifeq ($(WIN32), $(filter $(WIN32),true yes y on 1))
+	@find . -maxdepth 1 -name '*.sln' -exec $(MSBUILD) -t:build -p:Configuration="Release-x86" \;
 else
-	@find . -maxdepth 1 -name '*.sln' -exec msbuild /t:Rebuild /nr:false \;
+	@$(MSBUILD) -t:build -p:Configuration=Release
+	@find . -maxdepth 1 -name '*.sln' -exec $(MSBUILD) -t:build -p:Configuration=Release \;
 endif
+
+all: engine-dependencies engine core
 
 clean: engine
-ifeq ("$(HAS_MSBUILD)","")
-	@find . -maxdepth 1 -name '*.sln' -exec xbuild /nologo /verbosity:quiet /p:TreatWarningsAsErrors=true /t:Clean \;
-else
-	@find . -maxdepth 1 -name '*.sln' -exec msbuild /t:Clean /nr:false \;
-endif
+	@command -v $(MSBUILD) >/dev/null || (echo "OpenRA requires the '$(MSBUILD)' tool provided by Mono >= 5.4."; exit 1)
+	@find . -maxdepth 1 -name '*.sln' -exec $(MSBUILD) -t:clean \;
 	@cd $(ENGINE_DIRECTORY) && make clean
 	@printf "The engine has been cleaned.\n"
 
@@ -136,13 +146,15 @@ ifneq ("$(LUA_FILES)","")
 	@luac -p $(LUA_FILES)
 endif
 
-check: utility stylecheck
+check: utility
+	@echo "Compiling in debug mode..."
+	@$(MSBUILD) -t:build -p:Configuration=Debug
+	@echo "Checking runtime assemblies..."
+	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-runtime-assemblies $(WHITELISTED_OPENRA_ASSEMBLIES) $(WHITELISTED_THIRDPARTY_ASSEMBLIES) $(WHITELISTED_CORE_ASSEMBLIES) $(WHITELISTED_MOD_ASSEMBLIES)
 	@echo "Checking for explicit interface violations..."
 	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-explicit-interfaces
-	@for i in $(PROJECT_DIRS) ; do \
-		echo "Checking for code style violations in $${i}...";\
-		mono --debug "$(ENGINE_DIRECTORY)/OpenRA.StyleCheck.exe" $${i};\
-	done
+	@echo "Checking for incorrect conditional trait interface overrides..."
+	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-conditional-trait-interface-overrides
 
 test: utility
 	@echo "Testing $(MOD_ID) mod MiniYAML..."

--- a/OpenRA.Mods.Example/OpenRA.Mods.Example.csproj
+++ b/OpenRA.Mods.Example/OpenRA.Mods.Example.csproj
@@ -1,77 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{4E5B38F7-4E99-4C92-BB39-9100CC7F3829}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>OpenRA.Mods.Example</RootNamespace>
-    <AssemblyName>OpenRA.Mods.Example</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <OutputPath>bin\Debug\</OutputPath>
+    <TargetFramework>net461</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
     <Optimize>true</Optimize>
+    <LangVersion>5</LangVersion>
+    <DebugSymbols>true</DebugSymbols>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputPath>../mods/example</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <CodeAnalysisRuleSet>../engine/OpenRA.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-      <Reference Include="System" />
-      <Reference Include="System.Core" />
-      <Reference Include="System.Drawing" />
-      <Reference Include="Eluant">
-        <HintPath>..\engine\thirdparty\download\Eluant.dll</HintPath>
-        <Private>False</Private>
-      </Reference>
+    <!-- Work around an issue where Rider does not detect files in the project root using the default glob -->
+    <Compile Include="**/*.cs" Exclude="$(DefaultItemExcludes)" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Widgets\Logic\TemplateMenuLogic.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Widgets\" />
-    <Folder Include="Widgets\Logic\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\engine\OpenRA.Mods.Common\OpenRA.Mods.Common.csproj">
-      <Project>{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}</Project>
-      <Name>OpenRA.Mods.Common</Name>
+    <Reference Include="Eluant">
+      <HintPath>../engine/thirdparty/download/Eluant.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <ProjectReference Include="../engine/OpenRA.Game/OpenRA.Game.csproj">
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\engine\OpenRA.Game\OpenRA.Game.csproj">
-      <Project>{0DFB103F-2962-400F-8C6D-E2C28CCBA633}</Project>
-      <Name>OpenRA.Game</Name>
+    <ProjectReference Include="../engine/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj">
       <Private>False</Private>
     </ProjectReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <AdditionalFiles Include="../engine/stylecop.json" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/example/" />
-    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/example/" />
-    <!--
-        We need to copy OpenRA.Mods.Cnc.pdb (not `.dll.pdb`). This is only necessary on Windows.
-        Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
-    -->
-    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/example/" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/example/" Condition="Exists('$(TargetPath).mdb')" />
-    <!-- Uncomment these lines when debugging or adding to this target
-    <Message Text="DEBUG OS:                     $(OS)"/>
-    <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
-    <Message Text="DEBUG TargetPath:             $(TargetPath)"/>
-    <Message Text="DEBUG TargetDir:              $(TargetDir)"/>
-    <Message Text="DEBUG TargetName:             $(TargetName)"/>
-	-->
+  <Target Name="DisableAnalyzers" BeforeTargets="CoreCompile" Condition="'$(Configuration)'=='Release'">
+    <!-- Disable code style analysis on Release builds to improve compile-time performance -->
+    <ItemGroup Condition="'$(Configuration)'=='Release'">
+      <Analyzer Remove="@(Analyzer)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/make.ps1
+++ b/make.ps1
@@ -5,28 +5,19 @@
 ###############################################################
 function All-Command
 {
-	If (!(Test-Path "*.sln"))
+	if ((CheckForDotnet) -eq 1)
 	{
 		return
 	}
 
-	$msBuild = FindMSBuild
-	$msBuildArguments = "/t:Rebuild /nr:false"
-	if ($msBuild -eq $null)
+	dotnet build /p:Configuration=Release /nologo
+	if ($lastexitcode -ne 0)
 	{
-		echo "Unable to locate an appropriate version of MSBuild."
+		Write-Host "Build failed. If just the development tools failed to build, try installing Visual Studio. You may also still be able to run the game." -ForegroundColor Red
 	}
 	else
 	{
-		$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
-		if ($proc.ExitCode -ne 0)
-		{
-			echo "Build failed. If just the development tools failed to build, try installing Visual Studio. You may also still be able to run the game."
-		}
-		else
-		{
-			echo "Build succeeded."
-		}
+		Write-Host "Build succeeded." -ForegroundColor Green
 	}
 }
 
@@ -37,25 +28,35 @@ function Clean-Command
 		return
 	}
 
-	$msBuild = FindMSBuild
-	$msBuildArguments = "/t:Clean /nr:false"
-	if ($msBuild -eq $null)
+	if ((CheckForDotnet) -eq 1)
 	{
-		echo "Unable to locate an appropriate version of MSBuild."
+		return
 	}
-	else
+
+	dotnet clean /nologo
+	rm *.dll
+	rm mods/*/*.dll
+	rm *.dll.config
+	rm *.pdb
+	rm mods/*/*.pdb
+	rm *.exe
+	rm ./*/bin -r
+	rm ./*/obj -r
+
+	rm $env:ENGINE_DIRECTORY/*.dll
+	rm $env:ENGINE_DIRECTORY/mods/*/*.dll
+	rm env:ENGINE_DIRECTORY/*.config
+	rm env:ENGINE_DIRECTORY/*.pdb
+	rm mods/*/*.pdb
+	rm env:ENGINE_DIRECTORY/*.exe
+	rm env:ENGINE_DIRECTORY/*/bin -r
+	rm env:ENGINE_DIRECTORY/*/obj -r
+	if (Test-Path env:ENGINE_DIRECTORY/thirdparty/download/)
 	{
-		$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
-		rm *.dll
-		rm *.dll.config
-		rm mods/*/*.dll
-		rm *.pdb
-		rm mods/*/*.pdb
-		rm *.exe
-		rm ./*/bin -r
-		rm ./*/obj -r
-		echo "Clean complete."
+		rmdir env:ENGINE_DIRECTORY/thirdparty/download -Recurse -Force
 	}
+
+	Write-Host "Clean complete." -ForegroundColor Green
 }
 
 function Version-Command
@@ -77,12 +78,12 @@ function Version-Command
 		}
 		else
 		{
-			echo "Not a git repository. The version will remain unchanged."
+			Write-Host "Not a git repository. The version will remain unchanged." -ForegroundColor Red
 		}
 	}
 	else
 	{
-		echo "Unable to locate Git. The version will remain unchanged."
+		Write-Host "Unable to locate Git. The version will remain unchanged." -ForegroundColor Red
 	}
 
 	if ($version -ne $null)
@@ -99,43 +100,37 @@ function Version-Command
 		$replacement = (gc $mod) -Replace ".*: User", ("{0}/{1}: User" -f $prefix, $version)
 		sc $mod $replacement
 
-		echo ("Version strings set to '{0}'." -f $version)
+		Write-Host ("Version strings set to '{0}'." -f $version)
 	}
 }
 
 function Test-Command
 {
-	if (Test-Path $utilityPath)
+	if ((CheckForUtility) -eq 1)
 	{
-		echo "Testing $modID mod MiniYAML"
-		Invoke-Expression "$utilityPath $modID --check-yaml"
+		return
 	}
-	else
-	{
-		UtilityNotFound
-	}
+
+	Write-Host "Testing $modID mod MiniYAML..." -ForegroundColor Cyan
+	Invoke-Expression "$utilityPath $modID --check-yaml"
 }
 
 function Check-Command
 {
-	if (Test-Path $utilityPath)
+	Write-Host "Compiling in debug configuration..." -ForegroundColor Cyan
+	dotnet build /p:Configuration=Debug /nologo
+	if ($lastexitcode -ne 0)
 	{
-		echo "Checking for explicit interface violations..."
-		Invoke-Expression "$utilityPath $modID --check-explicit-interfaces"
-	}
-	else
-	{
-		UtilityNotFound
+		Write-Host "Build failed." -ForegroundColor Red
 	}
 
-	if (Test-Path $styleCheckPath)
+	if ((CheckForUtility) -eq 0)
 	{
-		echo "Checking for code style violations in OpenRA.Mods.$modID..."
-		Invoke-Expression "$styleCheckPath OpenRA.Mods.$modID"
-	}
-	else
-	{
-		echo "$styleCheckPath could not be found. Build the project first using the `"all`" command."
+		Write-Host "Checking for explicit interface violations..." -ForegroundColor Cyan
+		Invoke-Expression "$utilityPath $modID --check-explicit-interfaces"
+
+		Write-Host "Checking for incorrect conditional trait interface overrides..." -ForegroundColor Cyan
+		Invoke-Expression "$utilityPath $modID --check-conditional-trait-interface-overrides"
 	}
 }
 
@@ -143,54 +138,53 @@ function Check-Scripts-Command
 {
 	if ((Get-Command "luac.exe" -ErrorAction SilentlyContinue) -ne $null)
 	{
-		echo "Testing Lua scripts..."
+		Write-Host "Testing Lua scripts..." -ForegroundColor Cyan
 		foreach ($script in ls "mods/*/maps/*/*.lua")
 		{
 			luac -p $script
 		}
-		echo "Check completed!"
+		Write-Host "Check completed!" -ForegroundColor Green
 	}
 	else
 	{
-		echo "luac.exe could not be found. Please install Lua."
+		Write-Host "luac.exe could not be found. Please install Lua." -ForegroundColor Red
 	}
 }
 
 function Docs-Command
 {
-	if (Test-Path $utilityPath)
+	if ((CheckForUtility) -eq 1)
 	{
-		Invoke-Expression "$utilityPath $modID --docs | Out-File -Encoding 'UTF8' DOCUMENTATION.md"
-		Invoke-Expression "$utilityPath $modID --lua-docs | Out-File -Encoding 'UTF8' Lua-API.md"
-		echo "Docs generated."
+		return
 	}
-	else
-	{
-		UtilityNotFound
-	}
+
+	./make.ps1 version
+	Invoke-Expression "$utilityPath $modID --docs | Out-File -Encoding 'UTF8' DOCUMENTATION.md"
+	Invoke-Expression "$utilityPath $modID --weapon-docs | Out-File -Encoding "UTF8" WEAPONS.md"
+	Invoke-Expression "$utilityPath $modID --lua-docs | Out-File -Encoding 'UTF8' Lua-API.md"
+	echo "Docs generated." -ForegroundColor Green
 }
 
-function FindMSBuild
+function CheckForUtility
 {
-	$key = "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0"
-	$property = Get-ItemProperty $key -ErrorAction SilentlyContinue
-	if ($property -eq $null -or $property.MSBuildToolsPath -eq $null)
+	if (Test-Path OpenRA.Utility.exe)
 	{
-		return $null
+		return 0
 	}
 
-	$path = Join-Path $property.MSBuildToolsPath -ChildPath "MSBuild.exe"
-	if (Test-Path $path)
-	{
-		return $path
-	}
-
-	return $null
+	Write-Host "OpenRA.Utility.exe could not be found. Build the project first using the `"all`" command." -ForegroundColor Red
+	return 1
 }
 
-function UtilityNotFound
+function CheckForDotnet
 {
-	echo "$utilityPath could not be found. Build the project first using the `"all`" command."
+	if ((Get-Command "dotnet" -ErrorAction SilentlyContinue) -eq $null) 
+	{
+		Write-Host "The 'dotnet' tool is required to compile OpenRA. Please install the .NET Core SDK or Visual Studio and try again. https://dotnet.microsoft.com/download" -ForegroundColor Red
+		return 1
+	}
+
+	return 0
 }
 
 function WaitForInput

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,10 @@
 MOD_ID="example"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="release-20190314"
+ENGINE_VERSION="playtest-20190825"
+
+# .dll filenames compiled by the mod solution for use by the runtime assembly check
+WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.Example.dll"
 
 ##############################################################################
 # Continuous Integration
@@ -65,7 +68,7 @@ PACKAGING_FAQ_URL="http://wiki.openra.net/FAQ"
 PACKAGING_AUTHORS="Example Mod authors"
 
 # The git tag to use for the macOS Launcher files.
-PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20171118"
+PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20190506"
 
 # Filename to use for the launcher executable on Windows.
 PACKAGING_WINDOWS_LAUNCHER_NAME="ExampleMod"
@@ -81,7 +84,7 @@ PACKAGING_WINDOWS_REGISTRY_KEY="OpenRAExampleMod"
 PACKAGING_WINDOWS_LICENSE_FILE="./COPYING"
 
 # The git tag to use for the AppImage dependencies.
-PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20180723"
+PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20190506"
 
 # Space delimited list of additional files/directories to copy from the engine directory
 # when packaging your mod. e.g. "./mods/modcontent" or "./mods/d2k/OpenRA.Mods.D2k.dll"
@@ -121,3 +124,14 @@ PACKAGING_APPIMAGE_DEPENDENCIES_SOURCE="https://github.com/OpenRA/AppImageSuppor
 
 # Temporary file name used when downloading the OpenRA AppImage dependencies.
 PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME="libs.tar.bz2"
+
+# List of .NET assemblies that we can guarantee exist
+# OpenRA.Game.dll is a harmless false positive that we can ignore
+WHITELISTED_OPENRA_ASSEMBLIES="OpenRA.Game.exe OpenRA.Utility.exe OpenRA.Platforms.Default.dll OpenRA.Mods.Common.dll OpenRA.Game.dll"
+
+# These are explicitly shipped alongside our core files by the packaging script
+WHITELISTED_THIRDPARTY_ASSEMBLIES="ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll MaxMind.Db.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll"
+
+# These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
+# This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories
+WHITELISTED_CORE_ASSEMBLIES="mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll"

--- a/mods/example/mod.yaml
+++ b/mods/example/mod.yaml
@@ -53,7 +53,8 @@ ChromeMetrics:
 Fonts:
 	Bold:
 		Font: common|FreeSansBold.ttf
-		Size:14
+		Size: 14
+		Ascender: 11
 
 MapGrid:
 	TileSize: 32, 32

--- a/mods/example/rules.yaml
+++ b/mods/example/rules.yaml
@@ -15,12 +15,12 @@ World:
 		Filename: template.pal
 		CursorPalette: true
 		ShadowIndex:
+	Selection:
 
 DummyActor:
 	BodyOrientation:
 	HitShape:
 	AlwaysVisible:
-
 
 Player:
 	AlwaysVisible:

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -75,8 +75,14 @@ else
 fi
 
 pushd "${ENGINE_DIRECTORY}" > /dev/null
-make linux-dependencies
-make core SDK="-sdk:4.5"
+make clean
+
+# linux-dependencies target will trigger the lua detection script, which we don't want during packaging
+make cli-dependencies geoip-dependencies
+sed "s/@LIBLUA51@/liblua5.1.so.0/" thirdparty/Eluant.dll.config.in > Eluant.dll.config
+
+make core
+make version VERSION="${ENGINE_VERSION}"
 make install-engine prefix="usr" DESTDIR="${BUILTDIR}/"
 make install-common-mod-files prefix="usr" DESTDIR="${BUILTDIR}/"
 
@@ -86,6 +92,11 @@ for f in ${PACKAGING_COPY_ENGINE_FILES}; do
 done
 
 popd > /dev/null
+
+echo "Building mod files"
+make core
+cp -Lr mods/* "${BUILTDIR}/usr/lib/openra/mods"
+
 popd > /dev/null
 
 # Add native libraries
@@ -97,20 +108,25 @@ else
 	wget -cq "${PACKAGING_APPIMAGE_DEPENDENCIES_SOURCE}" -O "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" || exit 3
 	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
 fi
+
 tar xf "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}"
 chmod a+x appimagetool-x86_64.AppImage
 
 echo "Building AppImage"
 
-# Add mod files
-cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/usr/lib/openra/mods"
+install -d "${BUILTDIR}/usr/bin"
+install -d "${BUILTDIR}/etc/mono/4.5"
+install -d "${BUILTDIR}/usr/lib/mono/4.5"
 
-install -Dm 0755 libSDL2.so "${BUILTDIR}/usr/lib/openra/"
-install -Dm 0644 include/SDL2-CS.dll.config "${BUILTDIR}/usr/lib/openra/"
-install -Dm 0755 libopenal.so "${BUILTDIR}/usr/lib/openra/"
-install -Dm 0644 include/OpenAL-CS.dll.config "${BUILTDIR}/usr/lib/openra/"
-install -Dm 0755 liblua.so "${BUILTDIR}/usr/lib/openra/"
-install -Dm 0644 include/Eluant.dll.config "${BUILTDIR}/usr/lib/openra/"
+install -Dm 0755 usr/bin/mono "${BUILTDIR}/usr/bin/"
+
+install -Dm 0644 /etc/mono/config "${BUILTDIR}/etc/mono/"
+install -Dm 0644 /etc/mono/4.5/machine.config "${BUILTDIR}/etc/mono/4.5"
+
+for f in $(ls usr/lib/mono/4.5/*.dll usr/lib/mono/4.5/*.exe); do install -Dm 0644 "$f" "${BUILTDIR}/usr/lib/mono/4.5/"; done
+for f in $(ls usr/lib/*.so usr/lib/*.so.*); do install -Dm 0755 "$f" "${BUILTDIR}/usr/lib/"; done
+
+rm -rf libs libs.tar.bz2
 
 # Add launcher and icons
 sed "s/{MODID}/${MOD_ID}/g" include/AppRun.in | sed "s/{MODNAME}/${PACKAGING_DISPLAY_NAME}/g" > AppRun.temp
@@ -149,7 +165,7 @@ install -m 0755 include/gtk-dialog.py "${BUILTDIR}/usr/bin/gtk-dialog.py"
 
 # travis-ci doesn't support mounting FUSE filesystems so extract and run the contents manually
 ./appimagetool-x86_64.AppImage --appimage-extract
-ARCH=x86_64 ./squashfs-root/AppRun "${BUILTDIR}" "${OUTPUTDIR}/${PACKAGING_INSTALLER_NAME}-${TAG}.AppImage"
+ARCH=x86_64 ./squashfs-root/AppRun "${BUILTDIR}" "${OUTPUTDIR}/${PACKAGING_INSTALLER_NAME}-${TAG}-x86_64.AppImage"
 
 # Clean up
-rm -rf openra-mod.temp openra-mod-server.temp openra-mod-utility.temp temp.desktop temp.xml AppRun.temp libSDL2.so libopenal.so liblua.so appimagetool-x86_64.AppImage squashfs-root "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" "${BUILTDIR}"
+rm -rf openra-mod.temp openra-mod-server.temp openra-mod-utility.temp temp.desktop temp.xml AppRun.temp appimagetool-x86_64.AppImage squashfs-root "${PACKAGING_APPIMAGE_DEPENDENCIES_TEMP_ARCHIVE_NAME}" "${BUILTDIR}"

--- a/packaging/linux/include/AppRun.in
+++ b/packaging/linux/include/AppRun.in
@@ -1,71 +1,23 @@
 #!/bin/sh
 
-# Make sure the user has a sufficiently recent version of mono on the PATH
-MINIMUM_MONO_VERSION="4.2"
-
-prompt_apt_install_mono_complete() {
-  command -v mono >/dev/null 2>&1 && command -v cert-sync >/dev/null 2>&1 && return 1
-  command -v apt-cache > /dev/null || return 1
-  command -v xdg-mime > /dev/null || return 1
-  command -v xdg-open > /dev/null || return 1
-  [ ! "$(xdg-mime query default x-scheme-handler/apt)" ] && return 1
-  apt-cache search --names-only mono-complete | cut -d' ' -f1 | grep "^mono-complete$" > /dev/null || return 1
-  return 0
-}
-
-make_version() {
-  echo "$1" | tr '.' '\n' | head -n 4 | xargs printf "%03d%03d%03d%03d";
-}
-
-mono_missing_or_old() {
-  command -v mono >/dev/null 2>&1 || return 0
-  command -v cert-sync >/dev/null 2>&1 || return 0
-  MONO_VERSION=$(mono --version | head -n1 | cut -d' ' -f5)
-  [ "$(make_version "${MONO_VERSION}")" -lt "$(make_version "${MINIMUM_MONO_VERSION}")" ] && return 0
-  return 1
-}
-
 HERE="$(dirname "$(readlink -f "${0}")")"
-export PATH="${HERE}"/usr/bin/:"${PATH}"
-export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
 
-# If mono is not installed, and the user has apt-cache, apt-url,
-# xdg-open, and either zenity or kdialog, then we can prompt to
-# automatically install the mono-complete package
-if prompt_apt_install_mono_complete; then
-  PROMPT_MESSAGE="{MODNAME} requires the Mono runtime.\nWould you like to install it now?"
-  if command -v zenity > /dev/null; then
-    zenity --no-wrap --question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
-  elif command -v kdialog > /dev/null; then
-    kdialog --title "{MODNAME}" --yesno "${PROMPT_MESSAGE}" && xdg-open apt://mono-complete && exit 0
-  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
-    "${HERE}/usr/bin/gtk-dialog.py" question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
-  fi
-fi
+# Override runtime paths
+export PATH="${HERE}/usr/bin:${PATH}"
+export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS}"
+export DYLD_LIBRARY_PATH="${HERE}/usr/lib:$DYLD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:$LD_LIBRARY_PATH"
+export MONO_PATH="${HERE}/usr/lib/mono/4.5"
+export MONO_CFG_DIR="${HERE}/etc"
+export MONO_CONFIG="${HERE}/etc/mono/config"
 
-if mono_missing_or_old; then
-  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater and the cert-sync utility.\nPlease install Mono using your system package manager."
-  if command -v zenity > /dev/null; then
-    zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
-  elif command -v kdialog > /dev/null; then
-    kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
-  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
-    "${HERE}/usr/bin/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
-  else
-    printf "${ERROR_MESSAGE}"
-  fi
-  exit 1
-fi
-
-# Some distros and self-compiled mono installations don't set up
-# the SSL required for http web queries. If we detect that these
-# are missing we can try and create a local sync as a fallback.
-if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "${HOME}/.config/.mono/certs" ]; then
-  if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
-    cert-sync --quiet --user /etc/pki/tls/certs/ca-bundle.crt
-  elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
-    cert-sync --quiet --user /etc/ssl/certs/ca-certificates.crt
-  fi
+# Update/create the mono certificate store to enable https web queries
+if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
+  mono "${HERE}/usr/lib/mono/4.5/cert-sync.exe" --quiet --user /etc/pki/tls/certs/ca-bundle.crt
+elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
+  mono "${HERE}/usr/lib/mono/4.5/cert-sync.exe" --quiet --user /etc/ssl/certs/ca-certificates.crt
+else
+  echo "WARNING: Unable to sync system certificate store - https requests will fail"
 fi
 
 # Run the game or server

--- a/packaging/linux/include/Eluant.dll.config
+++ b/packaging/linux/include/Eluant.dll.config
@@ -1,3 +1,0 @@
-<configuration>
-  <dllmap os="linux" dll="lua51.dll" target="./liblua.so" />
-</configuration>

--- a/packaging/linux/include/OpenAL-CS.dll.config
+++ b/packaging/linux/include/OpenAL-CS.dll.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-	<dllmap dll="soft_oal.dll" os="linux" target="./libopenal.so"/>
-</configuration>

--- a/packaging/linux/include/SDL2-CS.dll.config
+++ b/packaging/linux/include/SDL2-CS.dll.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-	<dllmap os="linux" dll="SDL2.dll" target="./libSDL2.so" />
-</configuration>

--- a/packaging/linux/include/mod-utility.in
+++ b/packaging/linux/include/mod-utility.in
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-# OpenRA.Utility relies on keeping the original working directory, so don't change directory 
+# OpenRA.Utility relies on keeping the original working directory, so don't change directory
 HERE="$(dirname "$(readlink -f "${0}")")"
-mono --debug ${HERE}/../lib/openra/OpenRA.Utility.exe {MODID} "$@"
+mono --debug "${HERE}/../lib/openra/OpenRA.Utility.exe" {MODID} "$@"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -68,7 +68,6 @@ rm "${PACKAGING_OSX_LAUNCHER_TEMP_ARCHIVE_NAME}"
 
 modify_plist "{DEV_VERSION}" "${TAG}" "${BUILTDIR}/OpenRA.app/Contents/Info.plist"
 modify_plist "{FAQ_URL}" "${PACKAGING_FAQ_URL}" "${BUILTDIR}/OpenRA.app/Contents/Info.plist"
-echo "Building core files"
 
 pushd ${TEMPLATE_ROOT} > /dev/null
 
@@ -92,8 +91,12 @@ else
 fi
 
 pushd ${ENGINE_DIRECTORY} > /dev/null
+echo "Building core files"
+
+make clean
 make osx-dependencies
-make core SDK="-sdk:4.5"
+make core
+make version VERSION="${ENGINE_VERSION}"
 make install-engine gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
 make install-common-mod-files gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
 
@@ -103,10 +106,13 @@ for f in ${PACKAGING_COPY_ENGINE_FILES}; do
 done
 
 popd > /dev/null
+
+echo "Building mod files"
+make core
+cp -Lr mods/* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
+
 popd > /dev/null
 
-# Add mod files
-cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/OpenRA.app/Contents/Resources/mods"
 cp "mod.icns" "${BUILTDIR}/OpenRA.app/Contents/Resources/${MOD_ID}.icns"
 
 pushd "${BUILTDIR}" > /dev/null

--- a/packaging/windows/buildpackage.nsi
+++ b/packaging/windows/buildpackage.nsi
@@ -1,4 +1,4 @@
-; Copyright 2007-2015 OpenRA developers (see AUTHORS)
+; Copyright 2007-2019 OpenRA developers (see AUTHORS)
 ; This file is part of OpenRA.
 ;
 ;  OpenRA is free software: you can redistribute it and/or modify
@@ -83,7 +83,6 @@ Section "Game" GAME
 	File "${SRCDIR}\AUTHORS"
 	File "${SRCDIR}\COPYING"
 	File "${SRCDIR}\${MOD_ID}.ico"
-	File "${SRCDIR}\SharpFont.dll"
 	File "${SRCDIR}\SDL2-CS.dll"
 	File "${SRCDIR}\OpenAL-CS.dll"
 	File "${SRCDIR}\global mix database.dat"
@@ -133,15 +132,12 @@ SectionEnd
 ;***************************
 Section "-DotNet" DotNet
 	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client" "Install"
+	; https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" "Release"
 	IfErrors error 0
-	IntCmp $0 1 0 error 0
-	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" "Install"
-	IfErrors error 0
-	IntCmp $0 1 done error done
+	IntCmp $0 394254 done error done
 	error:
-		MessageBox MB_OK ".NET Framework v4.5 or later is required to run OpenRA."
+		MessageBox MB_OK ".NET Framework v4.6.1 or later is required to run OpenRA."
 		Abort
 	done:
 SectionEnd
@@ -180,7 +176,6 @@ Function ${UN}Clean
 	Delete $INSTDIR\ICSharpCode.SharpZipLib.dll
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
 	Delete $INSTDIR\Open.Nat.dll
-	Delete $INSTDIR\SharpFont.dll
 	Delete $INSTDIR\VERSION
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -48,8 +48,6 @@ cd "${PACKAGING_DIR}"
 
 LAUNCHER_LIBS="-r:System.dll -r:System.Drawing.dll -r:System.Windows.Forms.dll -r:${BUILTDIR}/OpenRA.Game.exe"
 
-echo "Building core files"
-
 pushd ${TEMPLATE_ROOT} > /dev/null
 
 if [ ! -f "${ENGINE_DIRECTORY}/Makefile" ]; then
@@ -71,50 +69,75 @@ else
 	echo "Mod version ${MOD_VERSION} will remain unchanged.";
 fi
 
-pushd ${ENGINE_DIRECTORY} > /dev/null
-SRC_DIR="$(pwd)"
-make windows-dependencies
-make core SDK="-sdk:4.5"
-make install-engine gameinstalldir="" DESTDIR="${BUILTDIR}"
-make install-common-mod-files gameinstalldir="" DESTDIR="${BUILTDIR}"
-
-for f in ${PACKAGING_COPY_ENGINE_FILES}; do
-	mkdir -p "${BUILTDIR}/$(dirname "${f}")"
-	cp -r "${f}" "${BUILTDIR}/${f}"
-done
-
-popd > /dev/null
 popd > /dev/null
 
-# Add mod files
-cp -Lr "${TEMPLATE_ROOT}/mods/"* "${BUILTDIR}/mods"
-cp "mod.ico" "${BUILTDIR}/${MOD_ID}.ico"
-cp "${SRC_DIR}/OpenRA.Game.exe.config" "${BUILTDIR}"
+function build_platform()
+{
+	if [ "$1" = "x86" ]; then
+		IS_WIN32="WIN32=true"
+	else
+		IS_WIN32="WIN32=false"
+	fi
 
-# We need to set the loadFromRemoteSources flag for the launcher, but only for the "portable" zip package.
-# Windows automatically un-trusts executables that are extracted from a downloaded zip file
-cp "${SRC_DIR}/OpenRA.Game.exe.config" "${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe.config"
+	pushd ${TEMPLATE_ROOT} > /dev/null
 
-echo "Compiling Windows launcher"
-sed "s|DISPLAY_NAME|${PACKAGING_DISPLAY_NAME}|" "${SRC_DIR}/packaging/windows/WindowsLauncher.cs.in" | sed "s|MOD_ID|${MOD_ID}|" | sed "s|FAQ_URL|${PACKAGING_FAQ_URL}|" > "${BUILTDIR}/WindowsLauncher.cs"
-mcs -sdk:4.5 "${BUILTDIR}/WindowsLauncher.cs" -warn:4 -codepage:utf8 -warnaserror -out:"${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe" -t:winexe ${LAUNCHER_LIBS} -win32icon:"${BUILTDIR}/${MOD_ID}.ico"
-rm "${BUILTDIR}/WindowsLauncher.cs"
-mono "${SRC_DIR}/fixheader.exe" "${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe" > /dev/null
+	echo "Building core files ($1)"
+	pushd ${ENGINE_DIRECTORY} > /dev/null
 
-echo "Building Windows setup.exe"
-pushd "${PACKAGING_DIR}" > /dev/null
-makensis -V2 -DSRCDIR="${BUILTDIR}" -DDEPSDIR="${SRC_DIR}/thirdparty/download/windows" -DTAG="${TAG}" -DMOD_ID="${MOD_ID}" -DPACKAGING_WINDOWS_INSTALL_DIR_NAME="${PACKAGING_WINDOWS_INSTALL_DIR_NAME}" -DPACKAGING_WINDOWS_LAUNCHER_NAME="${PACKAGING_WINDOWS_LAUNCHER_NAME}" -DPACKAGING_DISPLAY_NAME="${PACKAGING_DISPLAY_NAME}" -DPACKAGING_WEBSITE_URL="${PACKAGING_WEBSITE_URL}" -DPACKAGING_AUTHORS="${PACKAGING_AUTHORS}" -DPACKAGING_WINDOWS_REGISTRY_KEY="${PACKAGING_WINDOWS_REGISTRY_KEY}" -DPACKAGING_WINDOWS_LICENSE_FILE="${TEMPLATE_ROOT}/${PACKAGING_WINDOWS_LICENSE_FILE}" buildpackage.nsi
-if [ $? -eq 0 ]; then
-	mv OpenRA.Setup.exe "${OUTPUTDIR}/${PACKAGING_INSTALLER_NAME}-$TAG.exe"
-fi
-popd > /dev/null
+	SRC_DIR="$(pwd)"
 
-echo "Packaging zip archive"
-pushd "${BUILTDIR}" > /dev/null
-find "${SRC_DIR}/thirdparty/download/windows/" -name '*.dll' -exec cp '{}' '.' ';'
-zip "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable.zip" -r -9 * --quiet
-mv "${PACKAGING_INSTALLER_NAME}-${TAG}-winportable.zip" "${OUTPUTDIR}"
-popd > /dev/null
+	make clean
+	make windows-dependencies "${IS_WIN32}"
+	make core "${IS_WIN32}"
+	make version VERSION="${ENGINE_VERSION}"
+	make install-engine gameinstalldir="" DESTDIR="${BUILTDIR}"
+	make install-common-mod-files gameinstalldir="" DESTDIR="${BUILTDIR}"
 
-# Cleanup
-rm -rf "${BUILTDIR}"
+	for f in ${PACKAGING_COPY_ENGINE_FILES}; do
+		mkdir -p "${BUILTDIR}/$(dirname "${f}")"
+		cp -r "${f}" "${BUILTDIR}/${f}"
+	done
+
+	popd > /dev/null
+
+	echo "Building mod files ($1)"
+	make core
+
+	cp -Lr mods/* "${BUILTDIR}/mods"
+
+	popd > /dev/null
+
+	cp "mod.ico" "${BUILTDIR}/${MOD_ID}.ico"
+	cp "${SRC_DIR}/OpenRA.Game.exe.config" "${BUILTDIR}"
+
+	# We need to set the loadFromRemoteSources flag for the launcher, but only for the "portable" zip package.
+	# Windows automatically un-trusts executables that are extracted from a downloaded zip file
+	cp "${SRC_DIR}/OpenRA.Game.exe.config" "${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe.config"
+
+ 	echo "Compiling Windows launcher ($1)"
+	sed "s|DISPLAY_NAME|${PACKAGING_DISPLAY_NAME}|" "${SRC_DIR}/packaging/windows/WindowsLauncher.cs.in" | sed "s|MOD_ID|${MOD_ID}|" | sed "s|FAQ_URL|${PACKAGING_FAQ_URL}|" > "${BUILTDIR}/WindowsLauncher.cs"
+	csc "${BUILTDIR}/WindowsLauncher.cs" -nologo -warn:4 -warnaserror -platform:"$1" -out:"${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe" -t:winexe ${LAUNCHER_LIBS} -win32icon:"${BUILTDIR}/${MOD_ID}.ico"
+	rm "${BUILTDIR}/WindowsLauncher.cs"
+	mono "${SRC_DIR}/OpenRA.PostProcess.exe" "${BUILTDIR}/${PACKAGING_WINDOWS_LAUNCHER_NAME}.exe" -LAA > /dev/null
+
+ 	echo "Building Windows setup.exe ($1)"
+	pushd "${PACKAGING_DIR}" > /dev/null
+	makensis -V2 -DSRCDIR="${BUILTDIR}" -DDEPSDIR="${SRC_DIR}/thirdparty/download/windows" -DTAG="${TAG}" -DMOD_ID="${MOD_ID}" -DPACKAGING_WINDOWS_INSTALL_DIR_NAME="${PACKAGING_WINDOWS_INSTALL_DIR_NAME}" -DPACKAGING_WINDOWS_LAUNCHER_NAME="${PACKAGING_WINDOWS_LAUNCHER_NAME}" -DPACKAGING_DISPLAY_NAME="${PACKAGING_DISPLAY_NAME}" -DPACKAGING_WEBSITE_URL="${PACKAGING_WEBSITE_URL}" -DPACKAGING_AUTHORS="${PACKAGING_AUTHORS}" -DPACKAGING_WINDOWS_REGISTRY_KEY="${PACKAGING_WINDOWS_REGISTRY_KEY}" -DPACKAGING_WINDOWS_LICENSE_FILE="${TEMPLATE_ROOT}/${PACKAGING_WINDOWS_LICENSE_FILE}" buildpackage.nsi
+	if [ $? -eq 0 ]; then
+		mv OpenRA.Setup.exe "${OUTPUTDIR}/${PACKAGING_INSTALLER_NAME}-${TAG}-${1}.exe"
+	fi
+	popd > /dev/null
+
+	echo "Packaging zip archive ($1)"
+	pushd "${BUILTDIR}" > /dev/null
+	find "${SRC_DIR}/thirdparty/download/windows/" -name '*.dll' -exec cp '{}' '.' ';'
+	zip "${PACKAGING_INSTALLER_NAME}-${TAG}-${1}-winportable.zip" -r -9 * --quiet
+	mv "${PACKAGING_INSTALLER_NAME}-${TAG}-${1}-winportable.zip" "${OUTPUTDIR}"
+	popd > /dev/null
+
+	# Cleanup
+	rm -rf "${BUILTDIR}"
+}
+
+build_platform "x86"
+build_platform "x64"


### PR DESCRIPTION
This changes the SDK to account for:

* https://github.com/OpenRA/OpenRA/pull/16316
* https://github.com/OpenRA/OpenRA/pull/16319
* https://github.com/OpenRA/OpenRA/pull/16345
* https://github.com/OpenRA/OpenRA/pull/16451
* https://github.com/OpenRA/OpenRA/pull/16506
* https://github.com/OpenRA/OpenRA/pull/16516
* https://github.com/OpenRA/OpenRA/pull/16529
* https://github.com/OpenRA/OpenRA/pull/16537
* https://github.com/OpenRA/OpenRA/pull/16580

Fixes #113.

This depends on changes that have not yet been merged upstream, and will break compatibility with the current stable release. I'll keep this as a draft until we are ready to push the next playtest.

## Update text for the release description

* Updated engine to `playtest-20190825`
* Updated toolchain to work with the new OpenRA engine
* Linux and macOS applications no longer require a system Mono installation
* Added 64-bit Windows installer and portable packages (with `-x86` and `-x64` filename suffixes)
* Changed AppImage filename to include `-x86_64` suffix.

This is a major update to the mod SDK. The following files have changed:
* `.travis.yml`
* `Makefile`
* `make.ps1`
* `mod.config`
* `ExampleMod.sln`
* `packaging/linux/buildpackage.sh`
* `packaging/linux/include/AppRun.in`
* `packaging/linux/include/Eluant.dll.config` (deleted)
* `packaging/linux/include/OpenAL-CS.dll.config` (deleted)
* `packaging/linux/include/SDL2-CS.dll.config` (deleted)
* `packaging/linux/include/mod-utility.in`
* `packaging/osx/buildpackage.sh`
* `packaging/windows/buildpackage.nsi`
* `packaging/windows/buildpackage.sh`

We recommend updating by making a backup of any custom icons you have set in the platform-specific packaging directories, deleting the `packaging` directory and all its contents, and then replacing it with the updated versions in this release before restoring your custom icons.  Note that several files have been deleted, so extracting the new files over the top of the existing structure is not sufficient.

`.travis.yml`, `Makefile`, `ExampleMod.sln`, and `make.ps1` should then be replaced with the updated versions in this release.

If your mod defines its own `sln` file you must update the Debug and Release configurations to build all projects as `Any CPU` and add a new `Release-x86` configuration that builds all dll projects using the `Release` configuration, and all exe projects using the `Release-x86` configuration. Refer to the `ExampleMod.sln` for more details.

The following changes made to `mod.config`:

* In the `Core Configuration` section:
  * Change `ENGINE_VERSION` to `playtest-20190825`
  * Add a new definition:
    ```bash
    # .dll filenames compiled by the mod solution for use by the runtime assembly check
    WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.Example.dll"
    ```
    If your mod has deleted the Example dll then you should instead define this as
    ```bash
    # .dll filenames compiled by the mod solution for use by the runtime assembly check
    WHITELISTED_MOD_ASSEMBLIES=""
    ```
    or if you have your own mod dll(s) this should instead specify their name(s) separated by spaces.
* In the `Packaging` section:
  * Change `PACKAGING_OSX_LAUNCHER_TAG` to `osx-launcher-20190506`
  * Change `PACKAGING_APPIMAGE_DEPENDENCIES_TAG` to `20190506`
* In the `Advanced Configuration` section:
  * Add new definitions:
    ```bash
    # List of .NET assemblies that we can guarantee exist
    # OpenRA.Game.dll is a harmless false positive that we can ignore
    WHITELISTED_OPENRA_ASSEMBLIES="OpenRA.Game.exe OpenRA.Utility.exe OpenRA.Platforms.Default.dll OpenRA.Mods.Common.dll OpenRA.Game.dll"

    # These are explicitly shipped alongside our core files by the packaging script
    WHITELISTED_THIRDPARTY_ASSEMBLIES="ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll MaxMind.Db.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll"

    # These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
    # This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories
    WHITELISTED_CORE_ASSEMBLIES="mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll"
    ```

If your mod includes any custom c# projects you must update their `csproj` files to use the new OpenRA standard template. Open each `csproj` file with a standard text editor and replace the file contents with the text in `OpenRA.Mods.Example/OpenRA.Mods.Example.csproj`. Find the `<OutputPath>` definition (line 9) and replace `example` with your mod ID.

This SDK version is *not* backwards compatible with previous OpenRA's engine versions, and you must proceed with the [Engine update guide](https://github.com/OpenRA/OpenRAModSDK/wiki/Updating-to-a-new-SDK-or-Engine-version) before your mod will run on the new release.