### PR TITLE
Packaging fixes for playtest-20191021

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,23 @@ addons:
 
 script:
  - make
- - . mod.config;
+ - |
+   . mod.config;
    awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format. File must be saved using unix-style (CR, not CRLF) line endings.\n"; travis_terminate 1);
-   if [ "${TRAVIS_TEST_MOD}" == "True" ]; then make test || travis_terminate 1; fi;
-   if [ "${TRAVIS_TEST_PACKAGING}" == "True" ]; then make check-packaging-scripts && ./packaging/package-all.sh test-0 || travis_terminate 1; fi
+   if [ "${TRAVIS_TEST_MOD}" == "True" ]; then
+     make test || travis_terminate 1;
+   fi;
+   if [ "${TRAVIS_TEST_PACKAGING}" == "True" ] || [ -n "${TRAVIS_TAG}" ]; then
+     wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb || travis_terminate 1;
+     wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb || travis_terminate 1;
+     sudo dpkg -i nsis-common_3.03-2_all.deb || travis_terminate 1;
+     sudo dpkg -i nsis_3.03-2_amd64.deb || travis_terminate 1;
+   fi
+   if [ "${TRAVIS_TEST_PACKAGING}" == "True" ] && [ -z "${TRAVIS_TAG}" ]; then
+     make check-packaging-scripts && ./packaging/package-all.sh test-0 || travis_terminate 1;
+   fi
 
 before_deploy:
- - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb
- - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb
- - sudo dpkg -i nsis-common_3.03-2_all.deb
- - sudo dpkg -i nsis_3.03-2_amd64.deb
  - mkdir build
  - make check-packaging-scripts && cd build && ../packaging/package-all.sh ${TRAVIS_TAG} ${PWD} && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 dist: xenial
 language: csharp
-mono: 5.20.1
+mono: 6.4.0
 
 addons:
   apt:

--- a/mod.config
+++ b/mod.config
@@ -68,7 +68,7 @@ PACKAGING_FAQ_URL="http://wiki.openra.net/FAQ"
 PACKAGING_AUTHORS="Example Mod authors"
 
 # The git tag to use for the macOS Launcher files.
-PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20190506"
+PACKAGING_OSX_LAUNCHER_TAG="osx-launcher-20191003"
 
 # Filename to use for the launcher executable on Windows.
 PACKAGING_WINDOWS_LAUNCHER_NAME="ExampleMod"
@@ -84,7 +84,7 @@ PACKAGING_WINDOWS_REGISTRY_KEY="OpenRAExampleMod"
 PACKAGING_WINDOWS_LICENSE_FILE="./COPYING"
 
 # The git tag to use for the AppImage dependencies.
-PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20190506"
+PACKAGING_APPIMAGE_DEPENDENCIES_TAG="20191004"
 
 # Space delimited list of additional files/directories to copy from the engine directory
 # when packaging your mod. e.g. "./mods/modcontent" or "./mods/d2k/OpenRA.Mods.D2k.dll"

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="example"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="playtest-20190825"
+ENGINE_VERSION="release-20191117"
 
 # .dll filenames compiled by the mod solution for use by the runtime assembly check
 WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.Example.dll"


### PR DESCRIPTION
Fixes #118.
Fixes #125.

Updates engine version to playtest-20191021.