### PR TITLE
Remove GeoLite2-Country.mmdb.gz from Windows Packaging Script

### DIFF
--- a/packaging/windows/buildpackage.nsi
+++ b/packaging/windows/buildpackage.nsi
@@ -87,7 +87,6 @@ Section "Game" GAME
 	File "${SRCDIR}\OpenAL-CS.dll"
 	File "${SRCDIR}\global mix database.dat"
 	File "${SRCDIR}\MaxMind.Db.dll"
-	File "${SRCDIR}\GeoLite2-Country.mmdb.gz"
 	File "${SRCDIR}\eluant.dll"
 	File "${SRCDIR}\rix0rrr.BeaconLib.dll"
 	File "${DEPSDIR}\soft_oal.dll"
@@ -182,7 +181,6 @@ Function ${UN}Clean
 	Delete $INSTDIR\${MOD_ID}.ico
 	Delete "$INSTDIR\global mix database.dat"
 	Delete $INSTDIR\MaxMind.Db.dll
-	Delete $INSTDIR\GeoLite2-Country.mmdb.gz
 	Delete $INSTDIR\KopiLua.dll
 	Delete $INSTDIR\soft_oal.dll
 	Delete $INSTDIR\SDL2.dll


### PR DESCRIPTION
Noticed that this is still there while updating RA Classic to playtest-20200303. The file doesn't exist in the playtest anymore and causes travis to fail while creating the windows installer. Removing it made travis pass properly.