### PR TITLE
Update for playtest-20200418

### DIFF
--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -7,14 +7,13 @@ set ListenPort=1234
 set AdvertiseOnline=True
 set Password=""
 
-set GeoIPDatabase=""
-
 set RequireAuthentication=False
 set ProfileIDBlacklist=""
 set ProfileIDWhitelist=""
 
 set EnableSingleplayer=False
 set EnableSyncReports=False
+set EnableGeoIP=True
 set ShareAnonymizedIPs=True
 
 @echo off
@@ -34,7 +33,7 @@ if not exist %ENGINE_DIRECTORY%\OpenRA.Game.exe goto noengine
 cd %ENGINE_DIRECTORY%
 
 :loop
-OpenRA.Server.exe Game.Mod=%MOD_ID% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+OpenRA.Server.exe Game.Mod=%MOD_ID% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 goto loop
 
 :noengine

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -40,14 +40,13 @@ LISTEN_PORT="${ListenPort:-"1234"}"
 ADVERTISE_ONLINE="${AdvertiseOnline:-"True"}"
 PASSWORD="${Password:-""}"
 
-GEOIP_DATABASE_PATH="${GeoIPDatabase:-""}"
-
 REQUIRE_AUTHENTICATION="${RequireAuthentication:-"False"}"
 PROFILE_ID_BLACKLIST="${ProfileIDBlacklist:-""}"
 PROFILE_ID_WHITELIST="${ProfileIDWhitelist:-""}"
 
 ENABLE_SINGLE_PLAYER="${EnableSingleplayer:-"False"}"
 ENABLE_SYNC_REPORTS="${EnableSyncReports:-"False"}"
+ENABLE_GEOIP="${EnableGeoIP:-"True"}"
 SHARE_ANONYMISED_IPS="${ShareAnonymizedIPs:-"True"}"
 
 SUPPORT_DIR="${SupportDir:-""}"
@@ -66,12 +65,12 @@ while true; do
      Server.Name="${NAME}" Server.ListenPort="${LISTEN_PORT}" \
      Server.AdvertiseOnline="${ADVERTISE_ONLINE}" \
      Server.Password="${PASSWORD}" \
-     Server.GeoIPDatabase="${GEOIP_DATABASE_PATH}" \
      Server.RequireAuthentication="${REQUIRE_AUTHENTICATION}" \
      Server.ProfileIDBlacklist="${PROFILE_ID_BLACKLIST}" \
      Server.ProfileIDWhitelist="${PROFILE_ID_WHITELIST}" \
      Server.EnableSingleplayer="${ENABLE_SINGLE_PLAYER}" \
      Server.EnableSyncReports="${ENABLE_SYNC_REPORTS}" \
+     Server.EnableGeoIP="${ENABLE_GEOIP}" \
      Server.ShareAnonymizedIPs="${SHARE_ANONYMISED_IPS}" \
      Engine.SupportDir="${SUPPORT_DIR}"
 done

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="example"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="playtest-20200329"
+ENGINE_VERSION="playtest-20200418"
 
 # .dll filenames compiled by the mod solution for use by the runtime assembly check
 WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.Example.dll"

--- a/packaging/windows/buildpackage.nsi
+++ b/packaging/windows/buildpackage.nsi
@@ -86,7 +86,7 @@ Section "Game" GAME
 	File "${SRCDIR}\SDL2-CS.dll"
 	File "${SRCDIR}\OpenAL-CS.dll"
 	File "${SRCDIR}\global mix database.dat"
-	File "${SRCDIR}\MaxMind.Db.dll"
+	File "${SRCDIR}\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP"
 	File "${SRCDIR}\eluant.dll"
 	File "${SRCDIR}\rix0rrr.BeaconLib.dll"
 	File "${DEPSDIR}\soft_oal.dll"
@@ -180,8 +180,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\COPYING
 	Delete $INSTDIR\${MOD_ID}.ico
 	Delete "$INSTDIR\global mix database.dat"
-	Delete $INSTDIR\MaxMind.Db.dll
-	Delete $INSTDIR\KopiLua.dll
+	Delete $INSTDIR\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	Delete $INSTDIR\soft_oal.dll
 	Delete $INSTDIR\SDL2.dll
 	Delete $INSTDIR\lua51.dll


### PR DESCRIPTION
This PR bumps the engine version and adds compatibility for https://github.com/OpenRA/OpenRA/pull/17930.

Once this has been merged we can tag a new `20200418` release with notes:

<hr>

* Update engine reference for OpenRA playtest-20200418.
* Updated launch-dedicated and windows packaging for compatibility with playtest-20200418.
* Fixed an error relating to the engine VERSION file when updating a mod under Windows.

This is a minor update. The following files have changed:
* `launch-dedicated.cmd`
* `launch-dedicated.sh`
* `make.cmd`
* `packaging/windows/buildpackage.nsi`

To update from the `20200329` SDK release simply copy the new versions of `launch-dedicated.cmd`, `launch-dedicated.sh`, `make.cmd`, `packaging/windows/buildpackage.nsi` into your mod project and change `ENGINE_VERSION` to `playtest-20200418` in your mod.config.