### PR TITLE
Update to release-20210321

### DIFF
--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -57,7 +57,7 @@ SHARE_ANONYMISED_IPS="${ShareAnonymizedIPs:-"True"}"
 SUPPORT_DIR="${SupportDir:-""}"
 
 cd "${TEMPLATE_ROOT}"
-if [ ! -f "${ENGINE_DIRECTORY}/OpenRA.Game.exe" ] || [ "$(cat "${ENGINE_DIRECTORY}/VERSION")" != "${ENGINE_VERSION}" ]; then
+if [ ! -f "${ENGINE_DIRECTORY}/bin/OpenRA.Server.exe" ] || [ "$(cat "${ENGINE_DIRECTORY}/VERSION")" != "${ENGINE_VERSION}" ]; then
 	echo "Required engine files not found."
 	echo "Run \`make\` in the mod directory to fetch and build the required files, then try again.";
 	exit 1

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="example"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="playtest-20210131"
+ENGINE_VERSION="release-20210321"
 
 # .dll filenames compiled by the mod solution for use by the runtime assembly check
 WHITELISTED_MOD_ASSEMBLIES="OpenRA.Mods.Example.dll"


### PR DESCRIPTION
Ready to tag a new SDK release.

### Release notes for tag:

* Fix launch-dedicated.sh failing to detect the server files.
* Update engine reference for OpenRA release-20210321.

This is a minor update to target the latest engine version. The following files have changed:
* `launch-dedicated.sh`
* `mod.config`

Please see the notes for the [20210131](https://github.com/OpenRA/OpenRAModSDK/releases/tag/20210131) releases for instructions on how to update from earlier engine versions.