### PR TITLE
Fix for Windows uninstaller to remove reg entries from the 64 bit registry

### DIFF
--- a/packaging/windows/buildpackage.nsi
+++ b/packaging/windows/buildpackage.nsi
@@ -186,6 +186,10 @@ Function ${UN}Clean
 	Delete $INSTDIR\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	RMDir /r $INSTDIR\Support
 
+	!ifndef USE_PROGRAMFILES32
+		SetRegView 64
+	!endif
+
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PACKAGING_WINDOWS_REGISTRY_KEY}"
 	DeleteRegKey HKLM "Software\Classes\openra-${MOD_ID}-${TAG}"
 


### PR DESCRIPTION
On Windows, uninstalling the 64-bit version of an OpenRA mod leaves the registry entries behind. This leaves an entry in the Add/Remove Programs list which can't be removed unless you registry hack.

![image](https://user-images.githubusercontent.com/1639681/211816713-22a6b2b3-f70c-4883-b67e-92a4ae3eaa1c.png)

The fix was to call SetRegView 64 when uninstalling to specify the 64-bit registry. I tested both the 64 bit and 32 bit uninstall and they both function correctly and remove the registry entries OK.