### PR TITLE
Added launchSettings.json for launching via VS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"program": "${workspaceRoot}/engine/bin/OpenRA.Utility.dll",
-			"args": ["example", "--docs", "{DEV_VERSION}"],
+			"args": ["example", "--check-yaml"],
 			"env": {
 				"ENGINE_DIR": "${workspaceRoot}/engine",
 				"MOD_SEARCH_PATHS": "${workspaceRoot}/mods, ${workspaceRoot}/engine/mods"

--- a/OpenRA.Mods.Example/Properties/launchSettings.json
+++ b/OpenRA.Mods.Example/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+    "profiles": {
+        "OpenRA.Mods.Example": {
+            "commandName": "Executable",
+            "executablePath": "..\\..\\engine\\bin\\OpenRA.exe",
+            "commandLineArgs": "Game.Mod=example Engine.EngineDir=..\\..\\engine Engine.LaunchPath=..\\..\\engine\\bin Engine.ModSearchPaths=..\\..\\mods,..\\..\\engine\\mods Debug.DisplayDeveloperSettings=true"
+        }
+    }
+}

--- a/OpenRA.Mods.Example/Properties/launchSettings.json
+++ b/OpenRA.Mods.Example/Properties/launchSettings.json
@@ -4,6 +4,15 @@
             "commandName": "Executable",
             "executablePath": "..\\..\\engine\\bin\\OpenRA.exe",
             "commandLineArgs": "Game.Mod=example Engine.EngineDir=..\\..\\engine Engine.LaunchPath=..\\..\\engine\\bin Engine.ModSearchPaths=..\\..\\mods,..\\..\\engine\\mods Debug.DisplayDeveloperSettings=true"
+        },
+        "Utility": {
+            "commandName": "Executable",
+            "executablePath": "..\\..\\engine\\bin\\OpenRA.Utility.exe",
+            "commandLineArgs": "example --check-yaml",
+            "environmentVariables": {
+                "ENGINE_DIR": "..\\..\\engine",
+                "MOD_SEARCH_PATHS": "..\\..\\mods,..\\..\\engine\\mods"
+            }
         }
     }
 }


### PR DESCRIPTION
Over the last release cycle we added a bunch of tools to help launch and debug mods, mostly via VSCode and the missing piece was VS.
This is taken from the D2 mod and was added by @evgeniysergeev.