### PR TITLE
Correct launch-game.cmd join of quoted paths

### DIFF
--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -2,8 +2,8 @@
 setlocal EnableDelayedExpansion
 title OpenRA
 
-FOR /F "tokens=1,2 delims==" %%A IN (mod.config) DO (set %%A=%%B)
-if exist user.config (FOR /F "tokens=1,2 delims==" %%A IN (user.config) DO (set %%A=%%B))
+FOR /F "tokens=1,2 delims==" %%A IN (mod.config) DO (set %%A=%%~B)
+if exist user.config (FOR /F "tokens=1,2 delims==" %%A IN (user.config) DO (set %%A=%%~B))
 set TEMPLATE_LAUNCHER=%0
 set MOD_SEARCH_PATHS=%~dp0mods,./mods
 
@@ -12,9 +12,9 @@ if "!ENGINE_VERSION!" == "" goto badconfig
 if "!ENGINE_DIRECTORY!" == "" goto badconfig
 
 set TEMPLATE_DIR=%CD%
-if not exist %ENGINE_DIRECTORY%\bin\OpenRA.exe goto noengine
->nul find %ENGINE_VERSION% %ENGINE_DIRECTORY%\VERSION || goto noengine
-cd %ENGINE_DIRECTORY%
+if not exist "%ENGINE_DIRECTORY%\bin\OpenRA.exe" goto noengine
+>nul find %ENGINE_VERSION% "%ENGINE_DIRECTORY%\VERSION" || goto noengine
+cd "%ENGINE_DIRECTORY%"
 
 bin\OpenRA.exe Game.Mod=%MOD_ID% Engine.EngineDir=".." Engine.LaunchPath="%TEMPLATE_LAUNCHER%" Engine.ModSearchPaths="%MOD_SEARCH_PATHS%"  "%*"
 set ERROR=%errorlevel%


### PR DESCRIPTION
Unquote strings in launch-game.cmd and quote on use. Now correctly finds directory when there are quotes in the mod.config files.

fixes #175