### PR TITLE
Fix comment for PACKAGING_COPY_ENGINE_FILES variable in mod.config

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -84,7 +84,7 @@ PACKAGING_WINDOWS_REGISTRY_KEY="OpenRAExampleMod"
 PACKAGING_WINDOWS_LICENSE_FILE="./COPYING"
 
 # Space delimited list of additional files/directories to copy from the engine directory
-# when packaging your mod. e.g. "./mods/modcontent"
+# when packaging your mod. e.g. "./mods/common-content"
 PACKAGING_COPY_ENGINE_FILES=""
 
 # Overwrite the version in mod.yaml with the tag used for the SDK release


### PR DESCRIPTION
There's no longer a modcontent mod.